### PR TITLE
Add remediation points to violations

### DIFF
--- a/JSONRenderer.php
+++ b/JSONRenderer.php
@@ -4,46 +4,10 @@ namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
+use PHPMD\Category\Category;
 
 class JSONRenderer extends AbstractRenderer
 {
-    private $ruleCategories = array(
-      "CleanCode/BooleanArgumentFlag" => "Clarity",
-      "CleanCode/ElseExpression" => "Clarity",
-      "CleanCode/StaticAccess" => "Clarity",
-      "Controversial/CamelCaseClassName" => "Style",
-      "Controversial/CamelCaseMethodName" => "Style",
-      "Controversial/CamelCaseParameterName" => "Style",
-      "Controversial/CamelCasePropertyName" => "Style",
-      "Controversial/CamelCaseVariableName" => "Style",
-      "Controversial/Superglobals" => "Security",
-      "CyclomaticComplexity" => "Complexity",
-      "Design/CouplingBetweenObjects" => "Clarity",
-      "Design/DepthOfInheritance" => "Clarity",
-      "Design/EvalExpression" => "Security",
-      "Design/ExitExpression" => "Bug Risk",
-      "Design/GotoStatement" => "Clarity",
-      "Design/LongClass" => "Complexity",
-      "Design/LongMethod" => "Complexity",
-      "Design/LongParameterList" => "Complexity",
-      "Design/NpathComplexity" => "Complexity",
-      "Design/NumberOfChildren" => "Clarity",
-      "Design/TooManyFields" => "Complexity",
-      "Design/TooManyMethods" => "Complexity",
-      "Design/WeightedMethodCount" => "Complexity",
-      "ExcessivePublicCount" => "Complexity",
-      "Naming/BooleanGetMethodName" => "Style",
-      "Naming/ConstantNamingConventions" => "Style",
-      "Naming/ConstructorWithNameAsEnclosingClass" => "Compatability",
-      "Naming/LongVariable" => "Style",
-      "Naming/ShortMethodName" => "Style",
-      "Naming/ShortVariable" => "Style",
-      "UnusedFormalParameter" => "Bug Risk",
-      "UnusedLocalVariable" => "Bug Risk",
-      "UnusedPrivateField" => "Bug Risk",
-      "UnusedPrivateMethod" => "Bug Risk"
-    );
-
     public function renderReport(Report $report)
     {
         $writer = $this->getWriter();
@@ -51,19 +15,19 @@ class JSONRenderer extends AbstractRenderer
         foreach ($report->getRuleViolations() as $violation) {
             $rule = $violation->getRule();
             $checkName = preg_replace("/^PHPMD\/Rule\//", "", str_replace("\\", "/", get_class($rule)));
-
             $path = preg_replace("/^\/code\//", "", $violation->getFileName());
-            $category = $this->ruleCategories[$checkName];
 
-            if ($category == null) {
-                $category = "Style";
-            }
+            $category = Category::categoryFor($checkName);
+
+            $metric = $violation->getMetric();
+            $points = Category::pointsFor($checkName, $metric);
 
             $issue = array(
                 "type" => "issue",
                 "check_name" => $checkName,
                 "description" => $violation->getDescription(),
                 "categories" => array($category),
+                "remediation_points" => $points,
                 "location" => array(
                     "path" => $path,
                     "lines" => array(

--- a/category.php
+++ b/category.php
@@ -1,0 +1,65 @@
+<?php
+namespace PHPMD\Category;
+
+class Category
+{
+    public static $checks = array(
+        "CleanCode/BooleanArgumentFlag" => ["Clarity", 300000],
+        "CleanCode/ElseExpression" => ["Clarity", 200000],
+        "CleanCode/StaticAccess" => ["Clarity", 200000],
+        "Controversial/CamelCaseClassName" => ["Style", 500000],
+        "Controversial/CamelCaseMethodName" => ["Style", 1000],
+        "Controversial/CamelCaseParameterName" => ["Style", 500000],
+        "Controversial/CamelCasePropertyName" => ["Style", 500000],
+        "Controversial/CamelCaseVariableName" => ["Style", 25000],
+        "Controversial/Superglobals" => ["Security", 100000],
+        "CyclomaticComplexity" => ["Complexity", 100000],
+        "Design/CouplingBetweenObjects" => ["Clarity", 400000],
+        "Design/DepthOfInheritance" => ["Clarity", 500000],
+        "Design/EvalExpression" => ["Security", 300000],
+        "Design/ExitExpression" => ["Bug Risk", 200000],
+        "Design/GotoStatement" => ["Clarity", 200000],
+        "Design/LongClass" => ["Complexity", 200000],
+        "Design/LongMethod" => ["Complexity", 200000],
+        "Design/LongParameterList" => ["Complexity", 200000],
+        "Design/NpathComplexity" => ["Complexity", 200000],
+        "Design/NumberOfChildren" => ["Clarity", 1000000],
+        "Design/TooManyFields" => ["Complexity", 900000],
+        "Design/TooManyMethods" => ["Complexity", 2000000],
+        "Design/WeightedMethodCount" => ["Complexity", 2000000],
+        "ExcessivePublicCount" => ["Complexity", 700000],
+        "Naming/BooleanGetMethodName" => ["Style", 200000],
+        "Naming/ConstantNamingConventions" => ["Style", 100000],
+        "Naming/ConstructorWithNameAsEnclosingClass" => ["Compatability", 400000],
+        "Naming/LongVariable" => ["Style", 1000000],
+        "Naming/ShortMethodName" => ["Style", 800000],
+        "Naming/ShortVariable" => ["Style", 500000],
+        "UnusedFormalParameter" => ["Bug Risk", 200000],
+        "UnusedLocalVariable" => ["Bug Risk", 200000],
+        "UnusedPrivateField" => ["Bug Risk", 200000],
+        "UnusedPrivateMethod" => ["Bug Risk", 200000],
+    );
+
+    public static function pointsFor($checkName, $metric)
+    {
+        $points = self::$checks[$checkName][1];
+
+        if ($points && $metric) {
+            return $points *= $metric;
+        } else {
+            return $points;
+        }
+
+    }
+
+    public static function categoryFor($checkName)
+    {
+        $category = self::$checks[$checkName][0];
+
+        if ($category == null) {
+            $category = "Style";
+        }
+
+        return $category;
+    }
+}

--- a/engine.php
+++ b/engine.php
@@ -13,6 +13,7 @@ ini_set('memory_limit', -1);
 require_once __DIR__.'/vendor/autoload.php';
 require_once "JSONRenderer.php";
 require_once "Runner.php";
+require_once "Category.php";
 
 use PHPMD\PHPMD;
 use PHPMD\RuleSetFactory;


### PR DESCRIPTION
This is a first pass at adding remediation points to the violations
generated by PHPMD.
