### PR TITLE
Add content for PHPMD readups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+content

--- a/Category.php
+++ b/Category.php
@@ -62,4 +62,17 @@ class Category
 
         return $category;
     }
+
+    public static function documentationFor($checkName)
+    {
+        if (preg_match("/^Unused/i", $checkName)) {
+            $checkName = "Unused/" . $checkName;
+        }
+
+        $filePath = dirname(__FILE__) . "/content/" . strtolower($checkName) . ".txt";
+
+        if (file_exists($filePath)) {
+            return file_get_contents($filePath);
+        }
+    }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,21 @@ WORKDIR /usr/src/app
 COPY composer.json /usr/src/app/
 COPY composer.lock /usr/src/app/
 
-RUN apk --update add git php-common php-xml php-dom php-ctype php-iconv php-json php-pcntl php-phar php-openssl php-opcache php-sockets curl && \
+RUN apk --update add git php-common php-xml php-dom php-ctype php-iconv \
+    php-json php-pcntl php-phar php-openssl php-opcache php-sockets curl \
+    build-base ruby-dev ruby ruby-bundler && \
+    gem install httparty --no-rdoc --no-ri && \
     curl -sS https://getcomposer.org/installer | php && \
     /usr/src/app/composer.phar install && \
-    apk del build-base && rm -fr /usr/share/ri
-
-RUN adduser -u 9000 -D app
-USER app
+    apk del build-base
 
 COPY . /usr/src/app
+
+RUN adduser -u 9000 -D app
+RUN chown -R app .
+
+USER app
+
+RUN ./bin/build-content
 
 CMD ["/usr/src/app/bin/codeclimate-phpmd"]

--- a/JSONRenderer.php
+++ b/JSONRenderer.php
@@ -21,6 +21,7 @@ class JSONRenderer extends AbstractRenderer
 
             $metric = $violation->getMetric();
             $points = Category::pointsFor($checkName, $metric);
+            $content = Category::documentationFor($checkName);
 
             $issue = array(
                 "type" => "issue",
@@ -34,8 +35,14 @@ class JSONRenderer extends AbstractRenderer
                         "begin" => $violation->getBeginLine(),
                         "end" => $violation->getEndLine()
                     )
-                )
+                ),
             );
+
+            if ($content) {
+                $issue["content"] = array(
+                    "body" => $content
+                );
+            }
 
             $json = json_encode($issue, JSON_UNESCAPED_SLASHES, JSON_UNESCAPED_UNICODE);
             $writer->write($json);

--- a/bin/build-content
+++ b/bin/build-content
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+
+require 'httparty'
+require 'fileutils'
+
+CONTENT_DIR = "./content"
+
+categories = {
+  cleancode: "http://phpmd.org/rules/cleancode.txt",
+  codesize: "http://phpmd.org/rules/codesize.txt",
+  controversial: "http://phpmd.org/rules/controversial.txt",
+  design: "http://phpmd.org/rules/design.txt",
+  naming: "http://phpmd.org/rules/naming.txt",
+  unused: "http://phpmd.org/rules/unusedcode.txt"
+}
+
+FileUtils.rm_rf(CONTENT_DIR)
+
+categories.each do |category, url|
+  category_path = "#{CONTENT_DIR}/#{category}/"
+  FileUtils.mkdir_p(category_path)
+
+  text = HTTParty.get(url).body
+
+  matches = text.split(/=+\n.*?\n=+/, 2).pop
+  matches = matches.split(/^=+\n$/)
+
+  sections = matches.each_with_object([]) do |match, array|
+    split = match.split(/\n/)
+    title = split.pop
+    body = split.join("\n")
+
+    body.gsub!(/(?<=Example:) ::/, "\n\n```php")
+    body = body.split(/This rule.*/).shift
+    body += "\n```"
+
+
+    array << body
+    array << title
+  end
+
+  sections.shift
+  sections.pop
+
+  sections.each_slice(2) do |(header, body)|
+    next if header == "Remark"
+
+    file_name = header.gsub(" ", "_").downcase
+    File.open("#{category_path}/#{file_name}.txt", "w") do |file|
+      file.write(body)
+    end
+  end
+end


### PR DESCRIPTION
This adds a hacky Ruby script to fetch the .txt versions of PHPMD rule
documentation and format it in the correct folder structure for the
engine to read.
