### PR TITLE
Engine accepts paths to custom ruleset

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -71,7 +71,7 @@ class Runner
         $configRulesets = explode(',', $configRulesets);
 
         foreach ($configRulesets as &$r) {
-            if (!in_array($r, $officialPhpRulesets)) {
+            if (!in_array($r, $officialPhpRulesets) and $r[0] != "/") {
                 $r  = "/code/$r";
             }
         }

--- a/Runner.php
+++ b/Runner.php
@@ -9,6 +9,8 @@ use PHPMD\Renderer\JSONRenderer;
 
 class Runner
 {
+    const RULESETS = 'cleancode,codesize,controversial,design,naming,unusedcode';
+
     private $config;
     private $server;
 
@@ -63,6 +65,19 @@ class Runner
         }
     }
 
+    public function prefixCodeDirectory($configRulesets) {
+        $officialPhpRulesets = explode(',', Runner::RULESETS);
+        $configRulesets = explode(',', $configRulesets);
+
+        foreach ($configRulesets as &$r) {
+            if (!in_array($r, $officialPhpRulesets)) {
+             $r  = "/code/$r";
+            }
+        }
+
+        return implode(',', $configRulesets);
+    }
+
     public function run($files)
     {
         $resultFile = tempnam(sys_get_temp_dir(), 'phpmd');
@@ -78,10 +93,11 @@ class Runner
             $phpmd->setFileExtensions(explode(',', $this->config['config']['file_extensions']));
         }
 
-        $rulesets = "cleancode,codesize,controversial,design,naming,unusedcode";
+        $rulesets = Runner::RULESETS;
 
         if (isset($this->config['config']['rulesets'])) {
             $rulesets = $this->config['config']['rulesets'];
+            $rulesets = $this->prefixCodeDirectory($rulesets);
         }
 
         $phpmd->processFiles(

--- a/Runner.php
+++ b/Runner.php
@@ -22,7 +22,7 @@ class Runner
 
     public function queueDirectory($dir, $prefix = '')
     {
-        if(isset($this->config['include_paths'])) {
+        if (isset($this->config['include_paths'])) {
             $this->queueWithIncludePaths();
         } else {
             $this->queuePaths($dir, $prefix, $this->config['exclude_paths']);
@@ -31,21 +31,21 @@ class Runner
         $this->server->process_work(false);
     }
 
-    public function queueWithIncludePaths() {
+    public function queueWithIncludePaths()
+    {
         foreach ($this->config['include_paths'] as $f) {
             if ($f !== '.' and $f !== '..') {
-
                 if (is_dir("/code$f")) {
                     $this->queuePaths("/code$f", "$f/");
                     continue;
                 }
-
                 $this->server->addwork(array("/code/$f"));
             }
         }
     }
 
-    public function queuePaths($dir, $prefix = '', $exclusions = []) {
+    public function queuePaths($dir, $prefix = '', $exclusions = [])
+    {
         $dir = rtrim($dir, '\\/');
 
         foreach (scandir($dir) as $f) {
@@ -65,13 +65,14 @@ class Runner
         }
     }
 
-    public function prefixCodeDirectory($configRulesets) {
+    public function prefixCodeDirectory($configRulesets)
+    {
         $officialPhpRulesets = explode(',', Runner::RULESETS);
         $configRulesets = explode(',', $configRulesets);
 
         foreach ($configRulesets as &$r) {
             if (!in_array($r, $officialPhpRulesets)) {
-             $r  = "/code/$r";
+                $r  = "/code/$r";
             }
         }
 
@@ -96,8 +97,9 @@ class Runner
         $rulesets = Runner::RULESETS;
 
         if (isset($this->config['config']['rulesets'])) {
-            $rulesets = $this->config['config']['rulesets'];
-            $rulesets = $this->prefixCodeDirectory($rulesets);
+            $rulesets = $this->prefixCodeDirectory(
+                $this->config['config']['rulesets']
+            );
         }
 
         $phpmd->processFiles(


### PR DESCRIPTION
When PHPMD gets run, it accepts rule names, e.g.
codesize,unusedcode,naming

as a comma separated string.

It also accepts paths to a custome rule defined by the user mixed
in. For example:

```
  phpmd:
    enabled: true
    config:
      rulesets: "unusedcode,codesize,cleancode,design,naming,phpmd.xml"
```

where `phpmd.xml` contains a custom rule set up by user.

Previously, our engine failed to honor that config setup because it didn't
prefix `/code/` to the path. The result was 0 issues found across board.

This change fixes that behavior.

cc @codeclimate/review @leftees
