### PR TITLE
Simplify and fix issue documentation

### DIFF
--- a/Category.php
+++ b/Category.php
@@ -65,11 +65,11 @@ class Category
 
     public static function documentationFor($checkName)
     {
-        if (preg_match("/^Unused/i", $checkName)) {
-            $checkName = "Unused/" . $checkName;
-        }
+        $rule = array_pop(
+            explode("/", $checkName)
+        );
 
-        $filePath = dirname(__FILE__) . "/content/" . strtolower($checkName) . ".txt";
+        $filePath = dirname(__FILE__) . "/content/" . strtolower($rule) . ".txt";
 
         if (file_exists($filePath)) {
             return file_get_contents($filePath);

--- a/bin/build-content
+++ b/bin/build-content
@@ -4,6 +4,9 @@ require 'httparty'
 require 'fileutils'
 
 CONTENT_DIR = "./content"
+FILE_NAME_OVERRIDES = {
+  "excessiveclasscomplexity" => "weightedmethodcount",
+}
 
 categories = {
   cleancode: "http://phpmd.org/rules/cleancode.txt",
@@ -15,11 +18,14 @@ categories = {
 }
 
 FileUtils.rm_rf(CONTENT_DIR)
+FileUtils.mkdir_p(CONTENT_DIR)
+
+def file_name(header)
+  file_name = header.gsub(" ", "_").downcase
+  FILE_NAME_OVERRIDES.fetch(file_name, file_name)
+end
 
 categories.each do |category, url|
-  category_path = "#{CONTENT_DIR}/#{category}/"
-  FileUtils.mkdir_p(category_path)
-
   text = HTTParty.get(url).body
 
   matches = text.split(/=+\n.*?\n=+/, 2).pop
@@ -34,7 +40,6 @@ categories.each do |category, url|
     body = body.split(/This rule.*/).shift
     body += "\n```"
 
-
     array << body
     array << title
   end
@@ -45,8 +50,7 @@ categories.each do |category, url|
   sections.each_slice(2) do |(header, body)|
     next if header == "Remark"
 
-    file_name = header.gsub(" ", "_").downcase
-    File.open("#{category_path}/#{file_name}.txt", "w") do |file|
+    File.open("#{CONTENT_DIR}/#{file_name(header)}.txt", "w") do |file|
       file.write(body)
     end
   end


### PR DESCRIPTION
This commit updates build-content script (invoked during docker build)
to write all rules to simply
`./content/{#rule}.txt`

instead of nesting them under:

`./content/#{category}/#{rule}.txt`

The update is cleaner and fixes a problem:
1) no complexity content due to phpmd quirky discrepancy between rule
category name in documentation and in phpmd code itself.

`!tldr`:
My first approach tried to make the doc path during
build  match the check-naming in phpmd code, but this was messy and required
conditional logic in a few places.

The rule names are unique so they suffice for the lookup.

https://github.com/codeclimate/codeclimate-phpmd/blob/master/Category.php#L72

@codeclimate/review 
