### PR TITLE
Demonstrate option of specifying path to custome xml ruleset in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Format the values for these config options per the [PHPMD documentation](http://
         enabled: true
         config:
           file_extensions: "php"
-          rulesets: "unusedcode"
+          rulesets: "unusedcode,codesize,naming,optional_relative_path_to_custom_ruleset.xml"
     ratings:
       paths:
       - "**.php"


### PR DESCRIPTION
Makes sense after [this recent update](https://github.com/codeclimate/codeclimate-phpmd/commit/166ca9559b30e80f55e5c2d1e3e877dbd7b3dcff).

Helps avoid configuration confusion like https://gist.github.com/gabriel403/7c30a4d20151db920f04.

@codeclimate/review 
