### PR TITLE
Run one file at a time

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -102,12 +102,14 @@ class Runner
             );
         }
 
-        $phpmd->processFiles(
-            implode(",", $files),
-            $rulesets,
-            array($renderer),
-            $ruleSetFactory
-        );
+        foreach ($files as &$file) {
+            $phpmd->processFiles(
+                $file,
+                $rulesets,
+                array($renderer),
+                $ruleSetFactory
+            );
+        }
 
         return $resultFile;
     }


### PR DESCRIPTION
In my testing, this `implode` call was taking a really long time to run,
and phpmd itself seemed faster when only given one file at a time.

@codeclimate/review 
