### PR TITLE
Include separator in directory expansion check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: image
+
+IMAGE_NAME ?= codeclimate/codeclimate-phpmd
+
+image:
+	docker build --tag codeclimate/codeclimate-phpmd .

--- a/Runner.php
+++ b/Runner.php
@@ -35,8 +35,8 @@ class Runner
     {
         foreach ($this->config['include_paths'] as $f) {
             if ($f !== '.' and $f !== '..') {
-                if (is_dir("/code$f")) {
-                    $this->queuePaths("/code$f", "$f/");
+                if (is_dir("/code/$f")) {
+                    $this->queuePaths("/code/$f", "$f");
                     continue;
                 }
                 $this->server->addwork(array("/code/$f"));


### PR DESCRIPTION
The intent of this function is to expand include_paths to individual files and
add each as a unit of work to the forking server. This gives the maximum amount
of concurrency given the server's configuration.

The check to see if the include_path was a directory prepended "/code", but
without a separator. For example, "/codeapp/lib/" instead of "/code/app/lib".
The check would return false and the entire directory would be added as a
single unit of work. This meant we achieved almost no concurrency and
customer's with large repositories would time out.

/cc @codeclimate/review
