### PR TITLE
Add category for check new in 2.3

### DIFF
--- a/Category.php
+++ b/Category.php
@@ -26,6 +26,7 @@ class Category
         "Design/NumberOfChildren" => ["Clarity", 1000000],
         "Design/TooManyFields" => ["Complexity", 900000],
         "Design/TooManyMethods" => ["Complexity", 2000000],
+        "Design/TooManyPublicMethods" => ["Complexity", 2000000],
         "Design/WeightedMethodCount" => ["Complexity", 2000000],
         "ExcessivePublicCount" => ["Complexity", 700000],
         "Naming/BooleanGetMethodName" => ["Style", 200000],

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.3
 
 WORKDIR /usr/src/app
 COPY composer.json /usr/src/app/


### PR DESCRIPTION
Since the update to PHPMD 2.3, we see invalid index warnings since this check
is not in our category map. The warnings don't cause errors and we fall through
to a default Style category and remediation, but these are more appropriate
values.

The values were chosen as the same as the too-many-methods check, by the
reasoning that the general task of reducing the size of objects is the same
remediation no matter the methods' visibilities. Note: we don't currently have
the facility to scale remediation by overage, which would make sense in this
case, but adding that has been deferred for now.

http://phpmd.org/rules/codesize.html#toomanypublicmethods

/cc @codeclimate/review
