### PR TITLE
Attribute source of contents

### DIFF
--- a/bin/build-content
+++ b/bin/build-content
@@ -52,6 +52,7 @@ categories.each do |category, url|
 
     File.open("#{CONTENT_DIR}/#{file_name(header)}.txt", "w") do |file|
       file.write(body)
+      file.write("\n\nSource: #{url}")
     end
   end
 end


### PR DESCRIPTION
Adds the URL from which the content was retrieved to the bottom of
each content markdown document.

c/ @codeclimate/review
