### PR TITLE
Add Design/DevelopmentCodeFragment category

### DIFF
--- a/Category.php
+++ b/Category.php
@@ -16,6 +16,7 @@ class Category
         "CyclomaticComplexity" => ["Complexity", 100000],
         "Design/CouplingBetweenObjects" => ["Clarity", 400000],
         "Design/DepthOfInheritance" => ["Clarity", 500000],
+        "Design/DevelopmentCodeFragment" => ["Security", 100000],
         "Design/EvalExpression" => ["Security", 300000],
         "Design/ExitExpression" => ["Bug Risk", 200000],
         "Design/GotoStatement" => ["Clarity", 200000],


### PR DESCRIPTION
PHPMD 2.3.0 began supporting Design/DevelopmentCodeFragment:
https://github.com/phpmd/phpmd/blob/master/src/main/resources/rulesets/design.xml#L194

It appears this is not supported by codeclimate-phpmd, see: https://codeclimate.com/github/josephdpurcell/drupal/builds/6
