### PR TITLE
Fix unescaped unicode encoding parameter

### DIFF
--- a/JSONRenderer.php
+++ b/JSONRenderer.php
@@ -53,7 +53,7 @@ class JSONRenderer extends AbstractRenderer
                 $issue["fingerprint"] = $fingerprint;
             }
 
-            $json = json_encode($issue, JSON_UNESCAPED_SLASHES, JSON_UNESCAPED_UNICODE);
+            $json = json_encode($issue, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
             $writer->write($json);
             $writer->write(chr(0));
         }

--- a/Runner.php
+++ b/Runner.php
@@ -2,6 +2,7 @@
 
 namespace CodeClimate\PHPMD;
 
+use Exception;
 use PHPMD\PHPMD;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;


### PR DESCRIPTION
3rd parameter for json_encode is a max depth limitation. `JSON_UNESCAPED_UNICODE` has an int value of 256 whereas the max depth value is 512 (so no matter this way). This patch restores the expected usage of UNESCAPED_UNICODE param which is to
encode multibyte Unicode characters literally.
