### PR TITLE
Fix uncatchable exception

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -2,6 +2,7 @@
 
 namespace CodeClimate\PHPMD;
 
+use Exception;
 use PHPMD\PHPMD;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;


### PR DESCRIPTION
L116 
`} catch (Exception $e) { // can't be caught because CodeClimate\PHPMD\Exception does not exist`
Another way to fix this is:
`} catch (\Exception $e) {`
