### PR TITLE
Revert "Fix uncatchable exception"

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -2,7 +2,6 @@
 
 namespace CodeClimate\PHPMD;
 
-use Exception;
 use PHPMD\PHPMD;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;


### PR DESCRIPTION
Reverts codeclimate/codeclimate-phpmd#27

A canary in our systems caught that this change did not seem to have the intended effect: exceptions that were previously being caught were no longer being caught.

@landrok I also tried removing the `use` line and changing to `catch(\Exception ...` instead: that also didn't seem to actually catch the exceptions. Might this be a difference between PHP versions? I'm going to go ahead with the revert to get `master` back to a stable state, but please let me know if you have more thoughts about this.

FYI @codeclimate/review 
