### PR TITLE
Use stricter fingerprints for some rules

### DIFF
--- a/Fingerprint.php
+++ b/Fingerprint.php
@@ -5,6 +5,8 @@ namespace PHPMD;
 class Fingerprint
 {
     const OVERRIDE_RULES = [
+      "Controversial/CamelCaseVariableName",
+      "Controversial/CamelCasePropertyName",
       "CyclomaticComplexity",
       "Design/LongClass",
       "Design/LongMethod",
@@ -16,6 +18,7 @@ class Fingerprint
       "Design/TooManyPublicMethods",
       "Design/WeightedMethodCount",
       "ExcessivePublicCount",
+      "Naming/ShortMethodName",
     ];
     private $name;
     private $path;


### PR DESCRIPTION
We received a report that this engine produces a number of fixed/new
issues on pull request comparisons. I looked at an example PR:

https://codeclimate.com/github/yiisoft/yii2/pull/13113

And saw that the issues showing up as fixed/new are these three.

The location reported by the underlying tool, phpmd, is fairly broad.
So, for example, the `Naming/ShortMethodName` rule checks that your
method names aren't too short, and reports the location as being from
the beginning of the method to the end of the method. This means, with
our default fingerprinting algorithm, that if you change the method _at
all_, we'll generate a new fingerprint for the issue, and it will show
up as fixed/new.

Some phpmd rules don't include a "name", but I confirmed that these
three do.