### PR TITLE
Use internal fingerprint for Design/CouplingBetweenObjects issues

### DIFF
--- a/Fingerprint.php
+++ b/Fingerprint.php
@@ -8,6 +8,7 @@ class Fingerprint
       "Controversial/CamelCaseVariableName",
       "Controversial/CamelCasePropertyName",
       "CyclomaticComplexity",
+      "Design/CouplingBetweenObjects",
       "Design/LongClass",
       "Design/LongMethod",
       "Design/LongParameterList",


### PR DESCRIPTION
This is a similar fix to d419bbb2228d49bf23c8ed23c25295bf0f8b416b.  This
type of issue should use a more flexible fingerprint (path, rule, method
name) instead of the source-based default fingerprint.