### PR TITLE
Avoid printing a php notice for each issue

### DIFF
--- a/Category.php
+++ b/Category.php
@@ -66,9 +66,9 @@ class Category
 
     public static function documentationFor($checkName)
     {
-        $rule = array_pop(
-            explode("/", $checkName)
-        );
+        $checkNameParts = explode("/", $checkName);
+        end($checkNameParts);
+        $rule = array_pop($checkNameParts);
 
         $filePath = dirname(__FILE__) . "/content/" . strtolower($rule) . ".txt";
 

--- a/tests/CategoryTest.php
+++ b/tests/CategoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PHPMD\Tests;
+
+use PHPMD\Category\Category;
+
+class CategoryTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testCategoryFor()
+    {
+        $category = Category::categoryFor("Design/EvalExpression");
+        $this->assertEquals("Security", $category);
+    }
+
+    public function testDocumentationFor()
+    {
+        $documentation = Category::documentationFor("Design/EvalExpression");
+        $this->assertContains("An eval-expression is untestable", $documentation);
+    }
+}


### PR DESCRIPTION
The interpreter wants us to do this `end` shenanigan. Getting this
method under test actually _required_ us to avoid the notice, which is
kind of cool.

(rebase, update target branch, and merge after #35)

Should help with #33.