### PR TITLE
Fixes exception bubbling for php7

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -119,7 +119,7 @@ class Runner
             }
 
             return $resultFile;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             error_log("Exception: " . $e->getMessage() . " in " . $e->getFile() . "\n" . $e->getTraceAsString());
             return $e;
         }

--- a/engine.php
+++ b/engine.php
@@ -39,7 +39,7 @@ $server->process_work(true);
 $results = $server->get_all_results();
 
 foreach ($results as $result_file) {
-    if (is_a($result_file, "Exception")) {
+    if (is_a($result_file, "Throwable")) {
         exit(1);
     }
 


### PR DESCRIPTION
I noticed some builds printing fatal errors, but exiting with status 0 and "Found 0 issues."
```
[DEBUG] phpmd:stable engine stderr: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to PHPMD\PHPMD::setFileExtensions() must be of the type array, null given, called in /usr/src/app/Runner.php on
line 101 and defined in /usr/src/app/vendor/phpmd/phpmd/src/main/php/PHPMD/PHPMD.php:136
Stack trace:
#0 /usr/src/app/Runner.php(101): PHPMD\PHPMD->setFileExtensions(NULL)
...
  thrown in /usr/src/app/vendor/phpmd/phpmd/src/main/php/PHPMD/PHPMD.php on line 136

Analysis complete! Found 0 issues.
```

It looks like this is because the exception flow changed in php7:
https://trowski.com/2015/06/24/throwable-exceptions-and-errors-in-php7/
http://php.net/manual/en/language.errors.php7.php

The main point being there is now a separation between `Exception` and `Error` objects:
> Throwable may be used in try/catch blocks to catch both Exception and Error objects (or any possible future exception types).
```
interface Throwable
    |- Exception implements Throwable
        |- ...
    |- Error implements Throwable
        |- TypeError extends Error
        ...
```

Rescuing the globally namespaced `\Throwable` will also rescue `Errors` such as this `TypeError`.  I can verify this leads to the correct behavior (the error message is also printed in our format from the catch block):
```
Running phpmd: Done!
error: (CC::Analyzer::Engine::EngineFailure) engine phpmd:stable failed with status 1 and stderr
Exception: Argument 1 passed to PHPMD\PHPMD::setFileExtensions() must be of the type array, null given, called in /usr/src/app/Runner.php on line 101 in /usr/src/app/vendor/phpmd/phpmd/src/main/php/PHPMD/PHPMD.php
#0 /usr/src/app/Runner.php(101): PHPMD\PHPMD->setFileExtensions(NULL)
...
```

I will make the same fix in `phpcodesniffer` assuming this fix goes well.
