### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ workflows:
           context: Quality
           requires:
             - test
+          filters:
+            branches:
+              only: /master|channel\/[\w-]+/
 
 
 notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,12 @@ jobs:
     steps:
       - checkout
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
-              us.gcr.io/code-climate/codeclimate-phpmd:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-phpmd:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 
 workflows:
   version: 2
@@ -42,6 +41,7 @@ workflows:
           requires:
             - build
       - release_images:
+          context: Quality
           requires:
             - test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.15.0
 LABEL maintainer="Code Climate <hello@codeclimate.com>"
 
 WORKDIR /usr/src/app
@@ -37,13 +37,13 @@ RUN composer install --no-dev && \
 
 # Build Content
 COPY bin/build-content ./bin/build-content
-RUN apk add --no-cache ruby ruby-json ruby-bigdecimal ruby-dev build-base libxml2-dev libxslt-dev libffi-dev && \
+RUN apk add --no-cache ruby ruby-json ruby-bigdecimal ruby-dev build-base libxml2-dev libxslt-dev libffi-dev yaml-dev && \
     gem install rdoc nokogiri httparty --no-document && \
     ./bin/build-content && \
     chown -R app:app content && \
     gem uninstall --all rdoc httparty nokogiri && \
     rm -rf $( gem environment gemdir ) && \
-    apk del --purge ruby ruby-json ruby-bigdecimal ruby-dev build-base libxml2-dev libxslt-dev libffi-dev && \
+    apk del --purge ruby ruby-json ruby-bigdecimal ruby-dev build-base libxml2-dev libxslt-dev libffi-dev yaml-dev && \
     rm -rf /var/cache/* ~/.gem
 
 COPY . ./

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image composer-update test release tuki
+.PHONY: image composer-update test release
 
 IMAGE_NAME ?= codeclimate/codeclimate-phpmd
 RELEASE_REGISTRY ?= codeclimate

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: image composer-update test release
+.PHONY: image composer-update test release tuki
 
 IMAGE_NAME ?= codeclimate/codeclimate-phpmd
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --tag $(IMAGE_NAME) .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: image composer-update test
+.PHONY: image composer-update test release
 
 IMAGE_NAME ?= codeclimate/codeclimate-phpmd
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 image:
 	docker build --tag $(IMAGE_NAME) .
@@ -26,3 +28,7 @@ test:
 		--volume $(PWD)/tests:/usr/src/app/tests \
 		$(IMAGE_NAME)-test \
 		sh -c "vendor/bin/phpunit --bootstrap engine.php ./tests"
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-phpmd:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-phpmd:$(RELEASE_TAG)


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.

Also, replace base image from `alpine:edge` to `alpine:3.15.0` to prevent CI failure